### PR TITLE
Handle empty string params (values) properly

### DIFF
--- a/lib/sql_query_executor/query/normalizers/base_normalizer.rb
+++ b/lib/sql_query_executor/query/normalizers/base_normalizer.rb
@@ -11,6 +11,8 @@ module SqlQueryExecutor
           when "NilClass"
             nil
           when "String"
+            # Exit early if we have an empty string, otherwise a single ' will be returned
+            return "''" if(param == "")
             "'#{param}'".gsub("''", "'").gsub('""', '"')
           when "Date"
             "'#{param.strftime("%Y-%m-%d")}'"

--- a/spec/sql_query_executor/query/normalizers/origin_normalizer_spec.rb
+++ b/spec/sql_query_executor/query/normalizers/origin_normalizer_spec.rb
@@ -19,6 +19,17 @@ describe SqlQueryExecutor::Query::Normalizers::OriginNormalizer do
         end
       end
 
+      context 'when value is an empty string' do
+        let(:selector) { {id: ""} }
+        let(:query) { "id = ''" }
+
+        subject { described_class.execute(selector) }
+
+        it 'converts correctly' do
+          expect(subject).to eq(query)
+        end
+      end
+
       context 'when value is an integer' do
         let(:selector) { {id: 1} }
         let(:query) { "id = 1" }


### PR DESCRIPTION
avoid transforming them to single quotation mark.

With spec reproducing the bug I've encountered, which boiled down (used in `active_repository`) to getting bad query with empty string as parameter:
```
UserRepository.where(email: "")
=> #<ActiveRepository::ResultSet:0x000000071b8288 @attributes={:email=>""}, @klass=UserRepository, @query="email = '">
```
(notice the single quotation mark in `@query`)

How the spec will fail without the early return for empty string param:

```
Failures:

  1) SqlQueryExecutor::Query::Normalizers::OriginNormalizer.execute single selector when value is an empty string converts correctly
     Failure/Error: expect(subject).to eq(query)
       
       expected: "id = ''"
            got: "id = '"
       
       (compared using ==)
     # ./spec/sql_query_executor/query/normalizers/origin_normalizer_spec.rb:29:in `block (5 levels) in <top (required)>'

Failures:

  1) SqlQueryExecutor::Query::Normalizers::OriginNormalizer.execute single selector when value is an empty string converts correctly
     Failure/Error: expect(subject).to eq(query)
       
       expected: "id = ''"
            got: "id = '"
       
       (compared using ==)
     # ./spec/sql_query_executor/query/normalizers/origin_normalizer_spec.rb:29:in `block (5 levels) in <top (required)>'
```